### PR TITLE
Fixes (crash on Win10 and older)

### DIFF
--- a/NgsPacker/ViewModels/SettingsPageViewModel.cs
+++ b/NgsPacker/ViewModels/SettingsPageViewModel.cs
@@ -151,8 +151,18 @@ public class SettingsPageViewModel : BindableBase
         // フォルダ選択ダイアログ
         FolderPicker picker = new()
         {
-            Title = localizeService.GetLocalizedString("SelectPso2BinPathText"), InputPath = Pso2BinPath
+            Title = localizeService.GetLocalizedString("SelectPso2BinPathText"), /* InputPath = Pso2BinPath */
         };
+
+        // Somehow, if the "FolderPicker.InputPath" is assigned with a path to a non-existence directory, the FolderPicker class just stop working.
+        // This result in: clicking on "Browse" button in the UI makes nothing happen, for as long as the input textbox contains a non-existence path.
+
+        // Fix that by assignment only when the path is existed as a directory.
+        var localvar_Pso2BinPath = Pso2BinPath;
+        if (Directory.Exists(localvar_Pso2BinPath))
+        {
+            picker.InputPath = localvar_Pso2BinPath;
+        }
 
         // 出力先ファイルダイアログを表示
         if (picker.ShowDialog() != true)

--- a/NgsPacker/Views/ShellWindow.xaml.cs
+++ b/NgsPacker/Views/ShellWindow.xaml.cs
@@ -52,23 +52,31 @@ public partial class ShellWindow
                 sizeof(uint));
         }
 
-        // ウィンドウの角を丸くする
-        int rounded = (int)DWM_WINDOW_CORNER_PREFERENCE.DWMWCP_ROUND;
+        // These 2 window attributes are added on Windows 11.
+        // Windows 10 or older will not recognize the "DWMWINDOWATTRIBUTE.DWMWA_WINDOW_CORNER_PREFERENCE" and "DWMWINDOWATTRIBUTE.DWMWA_SYSTEMBACKDROP_TYPE"
+        // Which will throw error, and since we don't handle exception/error here, the app will simply crash and exit.
 
-        DwmSetWindowAttribute(
-            hWnd.Handle,
-            DWMWINDOWATTRIBUTE.DWMWA_WINDOW_CORNER_PREFERENCE,
-            ref rounded,
-            sizeof(uint));
+        // Add condition that will apply these 2 attributes only on Win11 and newer
+        if (OperatingSystem.IsWindowsVersionAtLeast(11))
+        {
+            // ウィンドウの角を丸くする
+            int rounded = (int)DWM_WINDOW_CORNER_PREFERENCE.DWMWCP_ROUND;
 
-        // ウィンドウの背景を半透過にする
-        int bg = (int)DWM_SYSTEMBACKDROP_TYPE.DWMSBT_TABBEDWINDOW;
+            DwmSetWindowAttribute(
+                hWnd.Handle,
+                DWMWINDOWATTRIBUTE.DWMWA_WINDOW_CORNER_PREFERENCE,
+                ref rounded,
+                sizeof(uint));
 
-        DwmSetWindowAttribute(
-            hWnd.Handle,
-            DWMWINDOWATTRIBUTE.DWMWA_SYSTEMBACKDROP_TYPE,
-            ref bg,
-            sizeof(uint));
+            // ウィンドウの背景を半透過にする
+            int bg = (int)DWM_SYSTEMBACKDROP_TYPE.DWMSBT_TABBEDWINDOW;
+
+            DwmSetWindowAttribute(
+                hWnd.Handle,
+                DWMWINDOWATTRIBUTE.DWMWA_SYSTEMBACKDROP_TYPE,
+                ref bg,
+                sizeof(uint));
+        }
     }
 
     private void Window_ContentRendered(object sender, EventArgs e)


### PR DESCRIPTION
- Fixed crash on Win10 and older due to forcibly applying unrecognized window attributes.
- Fixed "browse" button in setting page sometimes does nothing